### PR TITLE
Fix donate text font weight for better readability across themes (#1934)

### DIFF
--- a/feature/settings/src/main/java/com/t8rin/imagetoolbox/feature/settings/presentation/components/additional/DonateContainerContent.kt
+++ b/feature/settings/src/main/java/com/t8rin/imagetoolbox/feature/settings/presentation/components/additional/DonateContainerContent.kt
@@ -82,7 +82,7 @@ fun DonateContainerContent(
                 fontSize = 12.sp,
                 modifier = Modifier.padding(8.dp),
                 textAlign = TextAlign.Center,
-                fontWeight = FontWeight.SemiBold,
+                fontWeight = FontWeight.Normal,
                 lineHeight = 14.sp,
                 color = LocalContentColor.current.copy(alpha = 0.5f)
             )


### PR DESCRIPTION
This PR fixes issue #1934 by updating the donate text font weight from SemiBold to Normal for improved consistency and readability across themes, including dynamic color mode.

✅ Changes:
Changed font weight to Normal

Verified on Dark, Light, and Dynamic themes

Ensures consistent appearance across devices.