### PR TITLE
Fix permission request issues

### DIFF
--- a/core/ui/src/main/kotlin/com/t8rin/imagetoolbox/core/ui/utils/permission/PermissionUtils.kt
+++ b/core/ui/src/main/kotlin/com/t8rin/imagetoolbox/core/ui/utils/permission/PermissionUtils.kt
@@ -71,6 +71,14 @@ object PermissionUtils {
             return permissionResult
         }
 
+        val isAnyPermissionNotGiven =
+            permissionStatus.values.any { it == PermissionStatus.NOT_GIVEN }
+
+        if (isAnyPermissionNotGiven) {
+            permissionResult.finalStatus = PermissionStatus.NOT_GIVEN
+            return permissionResult
+        }
+
         permissionResult.finalStatus = PermissionStatus.ALLOWED
         return permissionResult
     }


### PR DESCRIPTION
- **Fixed `checkPermissions` function**:
      currently the function after deciding permission statuses, checking if there is any DENIED_PERMANENTLY status, then finalStatus changes to DENIED_PERMANENTLY otherwise finalStatus changes to ALLOWED, while NOT_GIVEN status not considered.
- **Used `requestPermissions` function instead of using pure `ActivityCompat.requestPermission`**:
Currently app have an issue in requsting permission, if user deny permission request for 2 times, after that Request button does not do anything, and that's because using `ActivityCompat.requestPermission` does not increase permission request count to  cause permission status DENIED_PERMANTELY in next tries, so i used the `requestPermissions` instead, and this issue fixed.
      