### PR TITLE
feat: add alignment to markup text tool

### DIFF
--- a/feature/markup-layers/src/main/java/com/t8rin/imagetoolbox/feature/markup_layers/domain/MarkupLayer.kt
+++ b/feature/markup-layers/src/main/java/com/t8rin/imagetoolbox/feature/markup_layers/domain/MarkupLayer.kt
@@ -76,11 +76,16 @@ sealed interface LayerType {
         val backgroundColor: Int,
         val text: String,
         val decorations: List<Decoration>,
-        val outline: Outline?
+        val outline: Outline?,
+        val alignment: Alignment
     ) : LayerType {
 
         enum class Decoration {
             Bold, Italic, Underline, LineThrough
+        }
+
+        enum class Alignment {
+            Start, Center, End
         }
 
         companion object {
@@ -93,6 +98,7 @@ sealed interface LayerType {
                     text = "Text",
                     decorations = listOf(),
                     outline = null,
+                    alignment = Alignment.Start,
                 )
             }
         }

--- a/feature/markup-layers/src/main/java/com/t8rin/imagetoolbox/feature/markup_layers/presentation/components/EditLayerSheet.kt
+++ b/feature/markup-layers/src/main/java/com/t8rin/imagetoolbox/feature/markup_layers/presentation/components/EditLayerSheet.kt
@@ -33,6 +33,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.BorderColor
+import androidx.compose.material.icons.rounded.FormatAlignCenter
+import androidx.compose.material.icons.rounded.FormatAlignLeft
+import androidx.compose.material.icons.rounded.FormatAlignRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -43,6 +46,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -193,6 +197,39 @@ internal fun EditLayerSheet(
                         keyboardOptions = KeyboardOptions(),
                         singleLine = false
                     )
+                    Spacer(Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally)
+                    ) {
+                        LayerType.Text.Alignment.entries.forEach { alignment ->
+                            EnhancedIconButton(
+                                onClick = {
+                                    onUpdateLayer(
+                                        layer.copy(
+                                            type = type.copy(alignment = alignment)
+                                        )
+                                    )
+                                },
+                                containerColor = takeColorFromScheme {
+                                    if (alignment == type.alignment) secondaryContainer else surface
+                                },
+                                contentColor = takeColorFromScheme {
+                                    if (alignment == type.alignment) onSecondaryContainer else onSurface
+                                }
+                            ) {
+                                Icon(
+                                    imageVector = when (alignment) {
+                                        LayerType.Text.Alignment.Start -> Icons.Rounded.FormatAlignLeft
+                                        LayerType.Text.Alignment.Center -> Icons.Rounded.FormatAlignCenter
+                                        LayerType.Text.Alignment.End -> Icons.Rounded.FormatAlignRight
+                                    },
+                                    contentDescription = null
+                                )
+                            }
+                        }
+                    }
+
                     Spacer(Modifier.height(8.dp))
                     FontSelector(
                         value = type.font.toUiFont(),

--- a/feature/markup-layers/src/main/java/com/t8rin/imagetoolbox/feature/markup_layers/presentation/components/LayerContent.kt
+++ b/feature/markup-layers/src/main/java/com/t8rin/imagetoolbox/feature/markup_layers/presentation/components/LayerContent.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -95,6 +96,11 @@ internal fun LayerContent(
                             FontStyle.Italic
                         } else {
                             FontStyle.Normal
+                        },
+                        textAlign = when (type.alignment) {
+                            LayerType.Text.Alignment.Start -> TextAlign.Start
+                            LayerType.Text.Alignment.Center -> TextAlign.Center
+                            LayerType.Text.Alignment.End -> TextAlign.End
                         }
                     )
                 }


### PR DESCRIPTION
## Description
This PR adds the ability to align text (Start, Center, End) within the `markup-layers` text editor. Previously, multi-line text was restricted to a single default alignment. This gives users much better control over how their text layers are laid out on the canvas.

## What was changed
* **Domain Model:** Added an `Alignment` enum to `LayerType.Text` in `MarkupLayer.kt` to store the user's alignment preference in the layer state (defaults to Center).
* **Canvas Rendering:** Updated `LayerContent.kt` to map the state alignment to Compose's native `TextAlign` property on the text elements.
* **UI:** Added a toggle row in `EditLayerSheet.kt` using `FormatAlignLeft`, `FormatAlignCenter`, and `FormatAlignRight` icons so users can easily swap alignments while editing the layer.

## Related Issue
Fixes #2556 

## Screenshots / Video
![Center Aligned Text](https://github.com/user-attachments/assets/3c6d1113-75f4-4c3d-9b18-30ec362863c4)
![Left Aligned Text](https://github.com/user-attachments/assets/eaf2d0ac-b7cb-4bdb-a870-ac1a30feceed)
![Right Aligned Text](https://github.com/user-attachments/assets/fdf9cc1e-8125-423b-9fea-6df217ff167f)


## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/T8RIN/ImageToolbox/blob/master/CONTRIBUTING.md) guide.
- [x] My code follows the code style of this project.
- [x] I kept this PR to a single commit.