### PR TITLE
Fix external image editing intent handling #2684

### DIFF
--- a/core/ui/src/main/kotlin/com/t8rin/imagetoolbox/core/ui/utils/helper/HandleDeeplinks.kt
+++ b/core/ui/src/main/kotlin/com/t8rin/imagetoolbox/core/ui/utils/helper/HandleDeeplinks.kt
@@ -122,6 +122,16 @@ fun Intent?.handleDeeplinks(
                     }
                 }
 
+                Intent.ACTION_EDIT,
+                Intent.ACTION_INSERT,
+                Intent.ACTION_INSERT_OR_EDIT -> {
+                    val uris = clipData?.clipList() ?: data?.let { listOf(it) } ?: return@runCatching
+                    if (type?.contains("gif") == true) {
+                        onHasExtraDataType(ExtraDataType.Gif)
+                    }
+                    onGetUris(uris)
+                }
+
                 else -> {
                     data?.let {
                         if (type?.contains("gif") == true) {

--- a/feature/root/src/main/java/com/t8rin/imagetoolbox/feature/root/presentation/screenLogic/RootComponent.kt
+++ b/feature/root/src/main/java/com/t8rin/imagetoolbox/feature/root/presentation/screenLogic/RootComponent.kt
@@ -375,22 +375,22 @@ class RootComponent @AssistedInject internal constructor(
     fun navigateTo(screen: Screen) {
         componentScope.launch {
             delay(100)
-            hideSelectDialog()
             screen.simpleName.makeLog("Navigator").also(analyticsManager::registerScreenOpen)
             navController.pushNew(screen)
+            hideSelectDialog()
         }
     }
 
     fun replaceTo(screen: Screen) {
         componentScope.launch {
             delay(100)
-            hideSelectDialog()
             screen.simpleName.makeLog("Navigator").also(analyticsManager::registerScreenOpen)
             navController.navigate(
                 transformer = { stack ->
                     stack.dropLastWhile { it !is Screen.PdfTools } + screen
                 }
-            )
+            )   
+            hideSelectDialog()
         }
     }
 


### PR DESCRIPTION
Fixes #2684

Found a potential race condition causing external image editing to fail on some devices.

Changes:

Added explicit handling for ACTION_EDIT, ACTION_INSERT, and ACTION_INSERT_OR_EDIT intents
Moved hideSelectDialog() to execute after navigation completes instead of before
This should prevent URIs from being cleared before the editor screen receives them. Couldn't reproduce the issue on my devices, so would appreciate testing from those who experienced it.