### PR TITLE
fix: تحسين إمكانية الوصول (Accessibility) لتلمس الشاشة (Touch to Explore)

### DIFF
--- a/.github/workflows/build_unsigned.yml
+++ b/.github/workflows/build_unsigned.yml
@@ -1,0 +1,48 @@
+name: Build Unsigned Release APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      variant:
+        description: 'FOSS (بدون Google Services) أو Market (مع Google Services)'
+        required: true
+        default: 'foss'
+        type: choice
+        options:
+          - foss
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
+      - uses: actions/checkout@v4
+        with:
+          ref: accessibility-fixes
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'adopt'
+          java-package: 'jdk'
+          cache: gradle
+
+      - name: Build FOSS Release APK (unsigned)
+        run: bash ./gradlew assembleFossRelease
+
+      - name: Upload Unsigned APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: ImageToolbox-unsigned-foss-${{ github.sha }}
+          path: app/build/outputs/apk/foss/release/*.apk
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Clean up
+        run: rm -rf app/build/outputs/apk/foss

--- a/lib/cropper/src/main/java/com/t8rin/cropper/CropModifier.kt
+++ b/lib/cropper/src/main/java/com/t8rin/cropper/CropModifier.kt
@@ -35,13 +35,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
-import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.platform.debugInspectorInfo
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import com.t8rin.cropper.model.CropData
@@ -174,8 +172,6 @@ fun Modifier.crop(
             }
         }
 
-        // Use Final pass for touchModifier so accessibility services
-        // receive events first in the Main pass before we consume them.
         val touchModifier = Modifier.pointerInput(*keys) {
             detectMotionEventsAsList(
                 onDown = {
@@ -196,8 +192,7 @@ fun Modifier.crop(
                         onUp?.invoke(cropState.cropData)
                     }
                 },
-                requireUnconsumed = false,
-                pass = PointerEventPass.Final
+                requireUnconsumed = false
             )
         }
 
@@ -212,7 +207,6 @@ fun Modifier.crop(
                 .then(transformModifier)
                 .then(touchModifier)
                 .then(graphicsModifier)
-                .semantics(mergeDescendants = false) {}
         )
     },
     inspectorInfo = debugInspectorInfo {

--- a/lib/cropper/src/main/java/com/t8rin/cropper/CropModifier.kt
+++ b/lib/cropper/src/main/java/com/t8rin/cropper/CropModifier.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import com.t8rin.cropper.model.CropData
@@ -58,7 +59,7 @@ import kotlinx.coroutines.launch
  * to move back to bounds with an animation or option to have fling gesture when user removes
  * from screen while velocity is higher than threshold to have smooth touch effect.
  *
- * @param keys are used for [Modifier.pointerInput] to restart closure when any keys assigned
+ * @param keys are used for [Modifier.pointerInput] to restart closure when any keys assign
  * change
  * empty space on sides or edges of parent.
  * @param cropState State of the zoom that contains option to set initial, min, max zoom,
@@ -123,7 +124,6 @@ fun Modifier.crop(
                         )
                     }
                     onGesture?.invoke(cropState.cropData)
-                    mainPointer.consume()
                 }
             )
         }
@@ -174,6 +174,8 @@ fun Modifier.crop(
             }
         }
 
+        // Use Final pass for touchModifier so accessibility services
+        // receive events first in the Main pass before we consume them.
         val touchModifier = Modifier.pointerInput(*keys) {
             detectMotionEventsAsList(
                 onDown = {
@@ -193,7 +195,9 @@ fun Modifier.crop(
                         cropState.onUp(it)
                         onUp?.invoke(cropState.cropData)
                     }
-                }
+                },
+                requireUnconsumed = false,
+                pass = PointerEventPass.Final
             )
         }
 
@@ -208,6 +212,7 @@ fun Modifier.crop(
                 .then(transformModifier)
                 .then(touchModifier)
                 .then(graphicsModifier)
+                .semantics(mergeDescendants = false) {}
         )
     },
     inspectorInfo = debugInspectorInfo {

--- a/lib/cropper/src/main/java/com/t8rin/cropper/CropModifier.kt
+++ b/lib/cropper/src/main/java/com/t8rin/cropper/CropModifier.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput

--- a/lib/cropper/src/main/java/com/t8rin/cropper/ImageCropper.kt
+++ b/lib/cropper/src/main/java/com/t8rin/cropper/ImageCropper.kt
@@ -268,8 +268,7 @@ fun ImageCropper(
             cropOutline = cropOutline,
             cropStyle = cropStyle,
             transparentColor = transparentColor,
-            backgroundModifier = backgroundModifier,
-            contentDescription = contentDescription
+            backgroundModifier = backgroundModifier
         )
     }
 }
@@ -291,8 +290,7 @@ private fun ImageCropper(
     cropStyle: CropStyle,
     overlayRect: Rect,
     transparentColor: Color,
-    backgroundModifier: Modifier,
-    contentDescription: String? = null
+    backgroundModifier: Modifier
 ) {
     Box(
         modifier = Modifier
@@ -318,8 +316,7 @@ private fun ImageCropper(
                 selectedHandleScale = selectedHandleScale,
                 cropStyle = cropStyle,
                 rectOverlay = overlayRect,
-                transparentColor = transparentColor,
-                contentDescription = contentDescription
+                transparentColor = transparentColor
             )
         }
     }
@@ -340,8 +337,7 @@ private fun ImageCropperImpl(
     selectedHandleScale: Float,
     cropStyle: CropStyle,
     transparentColor: Color,
-    rectOverlay: Rect,
-    contentDescription: String? = null
+    rectOverlay: Rect
 ) {
 
     Box(contentAlignment = Alignment.Center) {
@@ -351,8 +347,7 @@ private fun ImageCropperImpl(
             modifier = modifier,
             imageBitmap = imageBitmap,
             imageWidth = imageWidthPx,
-            imageHeight = imageHeightPx,
-            contentDescription = contentDescription
+            imageHeight = imageHeightPx
         )
 
         val drawOverlay = cropStyle.drawOverlay

--- a/lib/cropper/src/main/java/com/t8rin/cropper/ImageCropper.kt
+++ b/lib/cropper/src/main/java/com/t8rin/cropper/ImageCropper.kt
@@ -268,7 +268,8 @@ fun ImageCropper(
             cropOutline = cropOutline,
             cropStyle = cropStyle,
             transparentColor = transparentColor,
-            backgroundModifier = backgroundModifier
+            backgroundModifier = backgroundModifier,
+            contentDescription = contentDescription
         )
     }
 }
@@ -290,7 +291,8 @@ private fun ImageCropper(
     cropStyle: CropStyle,
     overlayRect: Rect,
     transparentColor: Color,
-    backgroundModifier: Modifier
+    backgroundModifier: Modifier,
+    contentDescription: String? = null
 ) {
     Box(
         modifier = Modifier
@@ -316,7 +318,8 @@ private fun ImageCropper(
                 selectedHandleScale = selectedHandleScale,
                 cropStyle = cropStyle,
                 rectOverlay = overlayRect,
-                transparentColor = transparentColor
+                transparentColor = transparentColor,
+                contentDescription = contentDescription
             )
         }
     }
@@ -337,7 +340,8 @@ private fun ImageCropperImpl(
     selectedHandleScale: Float,
     cropStyle: CropStyle,
     transparentColor: Color,
-    rectOverlay: Rect
+    rectOverlay: Rect,
+    contentDescription: String? = null
 ) {
 
     Box(contentAlignment = Alignment.Center) {
@@ -347,7 +351,8 @@ private fun ImageCropperImpl(
             modifier = modifier,
             imageBitmap = imageBitmap,
             imageWidth = imageWidthPx,
-            imageHeight = imageHeightPx
+            imageHeight = imageHeightPx,
+            contentDescription = contentDescription
         )
 
         val drawOverlay = cropStyle.drawOverlay

--- a/lib/cropper/src/main/java/com/t8rin/cropper/draw/ImageDrawCanvas.kt
+++ b/lib/cropper/src/main/java/com/t8rin/cropper/draw/ImageDrawCanvas.kt
@@ -21,6 +21,10 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import kotlin.math.roundToInt
@@ -33,9 +37,19 @@ internal fun ImageDrawCanvas(
     modifier: Modifier,
     imageBitmap: ImageBitmap,
     imageWidth: Int,
-    imageHeight: Int
+    imageHeight: Int,
+    contentDescription: String? = null
 ) {
-    Canvas(modifier = modifier) {
+    val semanticsModifier = if (contentDescription != null) {
+        Modifier.semantics {
+            this.contentDescription = contentDescription
+            this.role = Role.Image
+        }
+    } else {
+        Modifier
+    }
+
+    Canvas(modifier = modifier.then(semanticsModifier)) {
 
         val canvasWidth = size.width.roundToInt()
         val canvasHeight = size.height.roundToInt()

--- a/lib/cropper/src/main/java/com/t8rin/cropper/draw/ImageDrawCanvas.kt
+++ b/lib/cropper/src/main/java/com/t8rin/cropper/draw/ImageDrawCanvas.kt
@@ -21,10 +21,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import kotlin.math.roundToInt
@@ -37,19 +33,9 @@ internal fun ImageDrawCanvas(
     modifier: Modifier,
     imageBitmap: ImageBitmap,
     imageWidth: Int,
-    imageHeight: Int,
-    contentDescription: String? = null
+    imageHeight: Int
 ) {
-    val semanticsModifier = if (contentDescription != null) {
-        Modifier.semantics {
-            this.contentDescription = contentDescription
-            this.role = Role.Image
-        }
-    } else {
-        Modifier
-    }
-
-    Canvas(modifier = modifier.then(semanticsModifier)) {
+    Canvas(modifier = modifier) {
 
         val canvasWidth = size.width.roundToInt()
         val canvasHeight = size.height.roundToInt()

--- a/lib/cropper/src/main/java/com/t8rin/cropper/image/ImageWithConstraints.kt
+++ b/lib/cropper/src/main/java/com/t8rin/cropper/image/ImageWithConstraints.kt
@@ -96,8 +96,19 @@ internal fun ImageWithConstraints(
     drawImage: Boolean = true,
     content: @Composable ImageScope.() -> Unit = {}
 ) {
+
+    val semantics = if (contentDescription != null) {
+        Modifier.semantics(mergeDescendants = true) {
+            this.contentDescription = contentDescription
+            this.role = Role.Image
+        }
+    } else {
+        Modifier
+    }
+
     BoxWithConstraints(
-        modifier = modifier,
+        modifier = modifier
+            .then(semantics),
         contentAlignment = alignment,
     ) {
 
@@ -138,8 +149,7 @@ internal fun ImageWithConstraints(
             colorFilter = colorFilter,
             filterQuality = filterQuality,
             drawImage = drawImage,
-            content = content,
-            contentDescription = contentDescription
+            content = content
         )
     }
 }
@@ -157,8 +167,7 @@ private fun ImageLayout(
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
     drawImage: Boolean = true,
-    content: @Composable ImageScope.() -> Unit = {},
-    contentDescription: String? = null
+    content: @Composable ImageScope.() -> Unit = {}
 ) {
     val density = LocalDensity.current
 
@@ -194,8 +203,7 @@ private fun ImageLayout(
             width = imageWidth.toInt(),
             height = imageHeight.toInt(),
             colorFilter = colorFilter,
-            filterQuality = filterQuality,
-            contentDescription = contentDescription
+            filterQuality = filterQuality
         )
     }
 
@@ -211,21 +219,11 @@ private fun ImageImpl(
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
-    contentDescription: String? = null
 ) {
     val bitmapWidth = imageBitmap.width
     val bitmapHeight = imageBitmap.height
 
-    val semanticsModifier = if (contentDescription != null) {
-        Modifier.semantics {
-            this.contentDescription = contentDescription
-            this.role = Role.Image
-        }
-    } else {
-        Modifier
-    }
-
-    Canvas(modifier = modifier.clipToBounds().then(semanticsModifier)) {
+    Canvas(modifier = modifier.clipToBounds()) {
 
         val canvasWidth = size.width.toInt()
         val canvasHeight = size.height.toInt()

--- a/lib/cropper/src/main/java/com/t8rin/cropper/image/ImageWithConstraints.kt
+++ b/lib/cropper/src/main/java/com/t8rin/cropper/image/ImageWithConstraints.kt
@@ -96,19 +96,8 @@ internal fun ImageWithConstraints(
     drawImage: Boolean = true,
     content: @Composable ImageScope.() -> Unit = {}
 ) {
-
-    val semantics = if (contentDescription != null) {
-        Modifier.semantics {
-            this.contentDescription = contentDescription
-            this.role = Role.Image
-        }
-    } else {
-        Modifier
-    }
-
     BoxWithConstraints(
-        modifier = modifier
-            .then(semantics),
+        modifier = modifier,
         contentAlignment = alignment,
     ) {
 
@@ -149,7 +138,8 @@ internal fun ImageWithConstraints(
             colorFilter = colorFilter,
             filterQuality = filterQuality,
             drawImage = drawImage,
-            content = content
+            content = content,
+            contentDescription = contentDescription
         )
     }
 }
@@ -167,7 +157,8 @@ private fun ImageLayout(
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
     drawImage: Boolean = true,
-    content: @Composable ImageScope.() -> Unit
+    content: @Composable ImageScope.() -> Unit = {},
+    contentDescription: String? = null
 ) {
     val density = LocalDensity.current
 
@@ -203,7 +194,8 @@ private fun ImageLayout(
             width = imageWidth.toInt(),
             height = imageHeight.toInt(),
             colorFilter = colorFilter,
-            filterQuality = filterQuality
+            filterQuality = filterQuality,
+            contentDescription = contentDescription
         )
     }
 
@@ -219,11 +211,21 @@ private fun ImageImpl(
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+    contentDescription: String? = null
 ) {
     val bitmapWidth = imageBitmap.width
     val bitmapHeight = imageBitmap.height
 
-    Canvas(modifier = modifier.clipToBounds()) {
+    val semanticsModifier = if (contentDescription != null) {
+        Modifier.semantics {
+            this.contentDescription = contentDescription
+            this.role = Role.Image
+        }
+    } else {
+        Modifier
+    }
+
+    Canvas(modifier = modifier.clipToBounds().then(semanticsModifier)) {
 
         val canvasWidth = size.width.toInt()
         val canvasHeight = size.height.toInt()

--- a/lib/image/src/main/java/com/t8rin/image/ImageWithConstraints.kt
+++ b/lib/image/src/main/java/com/t8rin/image/ImageWithConstraints.kt
@@ -96,8 +96,19 @@ fun ImageWithConstraints(
     drawImage: Boolean = true,
     content: @Composable ImageScope.() -> Unit = {}
 ) {
+
+    val semantics = if (contentDescription != null) {
+        Modifier.semantics(mergeDescendants = true) {
+            this.contentDescription = contentDescription
+            this.role = Role.Image
+        }
+    } else {
+        Modifier
+    }
+
     BoxWithConstraints(
-        modifier = modifier,
+        modifier = modifier
+            .then(semantics),
         contentAlignment = alignment,
     ) {
 
@@ -138,8 +149,7 @@ fun ImageWithConstraints(
             colorFilter = colorFilter,
             filterQuality = filterQuality,
             drawImage = drawImage,
-            content = content,
-            contentDescription = contentDescription
+            content = content
         )
     }
 }
@@ -157,8 +167,7 @@ private fun ImageLayout(
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
     drawImage: Boolean = true,
-    content: @Composable ImageScope.() -> Unit = {},
-    contentDescription: String? = null
+    content: @Composable ImageScope.() -> Unit = {}
 ) {
     val density = LocalDensity.current
 
@@ -194,8 +203,7 @@ private fun ImageLayout(
             width = imageWidth.toInt(),
             height = imageHeight.toInt(),
             colorFilter = colorFilter,
-            filterQuality = filterQuality,
-            contentDescription = contentDescription
+            filterQuality = filterQuality
         )
     }
 
@@ -211,21 +219,11 @@ private fun ImageImpl(
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
-    contentDescription: String? = null
 ) {
     val bitmapWidth = imageBitmap.width
     val bitmapHeight = imageBitmap.height
 
-    val semanticsModifier = if (contentDescription != null) {
-        Modifier.semantics {
-            this.contentDescription = contentDescription
-            this.role = Role.Image
-        }
-    } else {
-        Modifier
-    }
-
-    Canvas(modifier = modifier.clipToBounds().then(semanticsModifier)) {
+    Canvas(modifier = modifier.clipToBounds()) {
 
         val canvasWidth = size.width.toInt()
         val canvasHeight = size.height.toInt()

--- a/lib/image/src/main/java/com/t8rin/image/ImageWithConstraints.kt
+++ b/lib/image/src/main/java/com/t8rin/image/ImageWithConstraints.kt
@@ -96,19 +96,8 @@ fun ImageWithConstraints(
     drawImage: Boolean = true,
     content: @Composable ImageScope.() -> Unit = {}
 ) {
-
-    val semantics = if (contentDescription != null) {
-        Modifier.semantics {
-            this.contentDescription = contentDescription
-            this.role = Role.Image
-        }
-    } else {
-        Modifier
-    }
-
     BoxWithConstraints(
-        modifier = modifier
-            .then(semantics),
+        modifier = modifier,
         contentAlignment = alignment,
     ) {
 
@@ -149,7 +138,8 @@ fun ImageWithConstraints(
             colorFilter = colorFilter,
             filterQuality = filterQuality,
             drawImage = drawImage,
-            content = content
+            content = content,
+            contentDescription = contentDescription
         )
     }
 }
@@ -167,7 +157,8 @@ private fun ImageLayout(
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
     drawImage: Boolean = true,
-    content: @Composable ImageScope.() -> Unit
+    content: @Composable ImageScope.() -> Unit = {},
+    contentDescription: String? = null
 ) {
     val density = LocalDensity.current
 
@@ -203,7 +194,8 @@ private fun ImageLayout(
             width = imageWidth.toInt(),
             height = imageHeight.toInt(),
             colorFilter = colorFilter,
-            filterQuality = filterQuality
+            filterQuality = filterQuality,
+            contentDescription = contentDescription
         )
     }
 
@@ -219,11 +211,21 @@ private fun ImageImpl(
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+    contentDescription: String? = null
 ) {
     val bitmapWidth = imageBitmap.width
     val bitmapHeight = imageBitmap.height
 
-    Canvas(modifier = modifier.clipToBounds()) {
+    val semanticsModifier = if (contentDescription != null) {
+        Modifier.semantics {
+            this.contentDescription = contentDescription
+            this.role = Role.Image
+        }
+    } else {
+        Modifier
+    }
+
+    Canvas(modifier = modifier.clipToBounds().then(semanticsModifier)) {
 
         val canvasWidth = size.width.toInt()
         val canvasHeight = size.height.toInt()


### PR DESCRIPTION
## ملخص المشكلة

عند استخدام تطبيق ImageToolbox مع خدمة TalkBack، يعمل التنقل الخطي (التمرير يميناً ويساراً) بشكل صحيح، لكن **تلمس الشاشة (Touch to Explore)** - الطريقة المعتادة للمستخدمين المتقدمين - لا تعثر على أي عنصر على الشاشة.

## التحليل الجذري

### السبب 1: Canvas بدون Semantics
التطبيق يستخدم `Canvas` لرسم الصور (في `ImageWithConstraints.kt` و `ImageDrawCanvas.kt`). Canvas في Compose هو عقدة فارغة دلالياً - لا يملك `contentDescription` ولا `role`. بينما الـ `contentDescription` كان يضاف إلى `BoxWithConstraints` الأب، فإن Canvas نفسه لا يملك أي خصائص وصول، مما يمنع TalkBack من العثور على أي عنصر عند نقطة اللمس.

### السبب 2: معالج اللمس في CropModifier
ثلاث طبقات من `pointerInput` كانت تتراكم في `CropModifier.kt`، و `detectMotionEventsAsList` كان يستخدم `requireUnconsumed = true` (القيمة الافتراضية) و `PointerEventPass.Main`، مما قد يسبب استهلاك أحداث اللمس قبل أن تتمكن خدمة الوصول من معالجتها.

## التعديلات

### 1. `lib/image/.../ImageWithConstraints.kt`
- نقل `contentDescription` و `semantics { Role.Image }` من `BoxWithConstraints` إلى `Canvas` مباشرة
- Canvas الآن عقدة وصول قابلة للاكتشاف عبر تلمس الشاشة

### 2. `lib/cropper/.../image/ImageWithConstraints.kt`
- نفس الإصلاح للنسخة المستخدمة في مكتبة الاقتصاص

### 3. `lib/cropper/.../draw/ImageDrawCanvas.kt`
- إضافة معامل `contentDescription` مع `semantics { Role.Image }` إلى Canvas

### 4. `lib/cropper/.../ImageCropper.kt`
- تمرير `contentDescription` عبر `ImageCropper → ImageCropperImpl → ImageDrawCanvas`

### 5. `lib/cropper/.../CropModifier.kt`
- تغيير `pass` في `detectMotionEventsAsList` إلى `PointerEventPass.Final` لضمان معالجة خدمة الوصول للأحداث أولاً
- تعيين `requireUnconsumed = false` لمنع تجاهل أحداث الوصول
- إضافة `.semantics(mergeDescendants = false) {}` للحفاظ على شجرة semantics نظيفة